### PR TITLE
Skip checking for init script if G_OSX_INITSCRIPT is not set

### DIFF
--- a/menuscripts/select_default_os.sh
+++ b/menuscripts/select_default_os.sh
@@ -46,7 +46,11 @@ load_OS1()
     F_COMMAND_LINE="\"$O_COMMAND_LINE_OVERRRIDE\""
   else
     TMP_COMMAND_LINE1=$(echo "$O_COMMAND_LINE" | sed -e "s/root\=\/dev\/mmcblk0p2/root\=\/dev\/mmcblk0p$G_OS1_PARTITION/")
-    TMP_COMMAND_LINE2=$(echo "$TMP_COMMAND_LINE1" | sed -e "s/ init\=\/sbin\/preinit/init\=$(echo $G_OS1_INITSCRIPT)/")
+    if [ ! -z "$G_OS1_INITSCRIPT" ]; then
+		TMP_COMMAND_LINE2=$(echo "$TMP_COMMAND_LINE1" | sed -e "s/ init\=\/sbin\/preinit/init\=$(echo $G_OS1_INITSCRIPT)/")
+	else
+		TMP_COMMAND_LINE2=$TMP_COMMAND_LINE1
+    fi
     F_COMMAND_LINE="\"$TMP_COMMAND_LINE2\""
     if [ ! -z "$G_OS1_INIT_CMDLINE_APPENDS" ]; then 
       logger "Appending options to CMDLINE: $G_OS1_INIT_CMDLINE_APPENDS"
@@ -81,7 +85,11 @@ load_OS2()
     F_COMMAND_LINE="\"$O_COMMAND_LINE_OVERRRIDE\""
   else
     TMP_COMMAND_LINE1=$(echo "$O_COMMAND_LINE" | sed -e "s/root\=\/dev\/mmcblk0p2/root\=\/dev\/mmcblk0p$G_OS2_PARTITION/")
-    TMP_COMMAND_LINE2=$(echo "$TMP_COMMAND_LINE1" | sed -e "s/ init\=\/sbin\/preinit/init\=$(echo $G_OS2_INITSCRIPT)/")
+    if [ ! -z "$G_OS2_INITSCRIPT" ]; then
+		TMP_COMMAND_LINE2=$(echo "$TMP_COMMAND_LINE1" | sed -e "s/ init\=\/sbin\/preinit/init\=$(echo $G_OS2_INITSCRIPT)/")
+	else
+		TMP_COMMAND_LINE2=$TMP_COMMAND_LINE1
+    fi
     F_COMMAND_LINE="\"$TMP_COMMAND_LINE2\""
     if [ ! -z "$G_OS2_INIT_CMDLINE_APPENDS" ]; then 
       logger "Appending options to CMDLINE: $G_OS2_INIT_CMDLINE_APPENDS"
@@ -116,7 +124,11 @@ load_OS3()
     F_COMMAND_LINE="\"$O_COMMAND_LINE_OVERRRIDE\""
   else
     TMP_COMMAND_LINE1=$(echo "$O_COMMAND_LINE" | sed -e "s/root\=\/dev\/mmcblk0p2/root\=\/dev\/mmcblk0p$G_OS3_PARTITION/")
-    TMP_COMMAND_LINE2=$(echo "$TMP_COMMAND_LINE1" | sed -e "s/ init\=\/sbin\/preinit/init\=$(echo $G_OS3_INITSCRIPT)/")
+    if [ ! -z "$G_OS3_INITSCRIPT" ]; then
+		TMP_COMMAND_LINE2=$(echo "$TMP_COMMAND_LINE1" | sed -e "s/ init\=\/sbin\/preinit/init\=$(echo $G_OS3_INITSCRIPT)/")
+	else
+		TMP_COMMAND_LINE2=$TMP_COMMAND_LINE1
+    fi
     F_COMMAND_LINE="\"$TMP_COMMAND_LINE2\""
     if [ ! -z "$G_OS3_INIT_CMDLINE_APPENDS" ]; then 
       logger "Appending options to CMDLINE: $G_OS3_INIT_CMDLINE_APPENDS"
@@ -151,7 +163,11 @@ load_OS4()
     F_COMMAND_LINE="\"$O_COMMAND_LINE_OVERRRIDE\""
   else
     TMP_COMMAND_LINE1=$(echo "$O_COMMAND_LINE" | sed -e "s/root\=\/dev\/mmcblk0p2/root\=\/dev\/mmcblk0p$G_OS4_PARTITION/")
-    TMP_COMMAND_LINE2=$(echo "$TMP_COMMAND_LINE1" | sed -e "s/ init\=\/sbin\/preinit/init\=$(echo $G_OS4_INITSCRIPT)/")
+    if [ ! -z "$G_OS4_INITSCRIPT" ]; then
+		TMP_COMMAND_LINE2=$(echo "$TMP_COMMAND_LINE1" | sed -e "s/ init\=\/sbin\/preinit/init\=$(echo $G_OS4_INITSCRIPT)/")
+	else
+		TMP_COMMAND_LINE2=$TMP_COMMAND_LINE1
+    fi
     F_COMMAND_LINE="\"$TMP_COMMAND_LINE2\""
     if [ ! -z "$G_OS4_INIT_CMDLINE_APPENDS" ]; then 
       logger "Appending options to CMDLINE: $G_OS4_INIT_CMDLINE_APPENDS"
@@ -186,7 +202,11 @@ load_OS5()
     F_COMMAND_LINE="\"$O_COMMAND_LINE_OVERRRIDE\""
   else
     TMP_COMMAND_LINE1=$(echo "$O_COMMAND_LINE" | sed -e "s/root\=\/dev\/mmcblk0p2/root\=\/dev\/mmcblk0p$G_OS5_PARTITION/")
-    TMP_COMMAND_LINE2=$(echo "$TMP_COMMAND_LINE1" | sed -e "s/ init\=\/sbin\/preinit/init\=$(echo $G_OS5_INITSCRIPT)/")
+    if [ ! -z "$G_OS5_INITSCRIPT" ]; then
+		TMP_COMMAND_LINE2=$(echo "$TMP_COMMAND_LINE1" | sed -e "s/ init\=\/sbin\/preinit/init\=$(echo $G_OS5_INITSCRIPT)/")
+	else
+		TMP_COMMAND_LINE2=$TMP_COMMAND_LINE1
+    fi
     F_COMMAND_LINE="\"$TMP_COMMAND_LINE2\""
     if [ ! -z "$G_OS5_INIT_CMDLINE_APPENDS" ]; then 
       logger "Appending options to CMDLINE: $G_OS5_INIT_CMDLINE_APPENDS"
@@ -221,7 +241,11 @@ load_OS6()
     F_COMMAND_LINE="\"$O_COMMAND_LINE_OVERRRIDE\""
   else
     TMP_COMMAND_LINE1=$(echo "$O_COMMAND_LINE" | sed -e "s/root\=\/dev\/mmcblk0p2/root\=\/dev\/mmcblk0p$G_OS6_PARTITION/")
-    TMP_COMMAND_LINE2=$(echo "$TMP_COMMAND_LINE1" | sed -e "s/ init\=\/sbin\/preinit/init\=$(echo $G_OS6_INITSCRIPT)/")
+    if [ ! -z "$G_OS6_INITSCRIPT" ]; then
+		TMP_COMMAND_LINE2=$(echo "$TMP_COMMAND_LINE1" | sed -e "s/ init\=\/sbin\/preinit/init\=$(echo $G_OS6_INITSCRIPT)/")
+	else
+		TMP_COMMAND_LINE2=$TMP_COMMAND_LINE1
+    fi
     F_COMMAND_LINE="\"$TMP_COMMAND_LINE2\""
     if [ ! -z "$G_OS6_INIT_CMDLINE_APPENDS" ]; then 
       logger "Appending options to CMDLINE: $G_OS6_INIT_CMDLINE_APPENDS"

--- a/menuscripts/select_os_animated.sh
+++ b/menuscripts/select_os_animated.sh
@@ -138,7 +138,10 @@ try_to_mount()
 check_init_file()
 {
   G_INITFILENAME=$(echo "$1" | sed -e "s/\\\//g")
-
+  if [ -z "$G_INITFILENAME" ]; then
+    logger "Checking 2nd stage kernel init file skipped"
+    return 0
+  fi
   logger "Checking 2nd stage kernel init file on partition /dev/mmcblk0p$2"
   try_to_mount "/dev/mmcblk0p$2" "/mnt/$2"
   ret=$?
@@ -181,7 +184,11 @@ load_OS1()
     F_COMMAND_LINE="\"$O_COMMAND_LINE_OVERRRIDE\""
   else
     TMP_COMMAND_LINE1=$(echo "$O_COMMAND_LINE" | sed -e "s/root\=\/dev\/mmcblk0p2/root\=\/dev\/mmcblk0p$G_OS1_PARTITION/")
-    TMP_COMMAND_LINE2=$(echo "$TMP_COMMAND_LINE1" | sed -e "s/ init\=\/sbin\/preinit/init\=$(echo $G_OS1_INITSCRIPT)/")
+    if [ ! -z "$G_OS1_INITSCRIPT" ]; then
+		TMP_COMMAND_LINE2=$(echo "$TMP_COMMAND_LINE1" | sed -e "s/ init\=\/sbin\/preinit/init\=$(echo $G_OS1_INITSCRIPT)/")
+	else
+		TMP_COMMAND_LINE2=$TMP_COMMAND_LINE1
+    fi
     F_COMMAND_LINE="\"$TMP_COMMAND_LINE2\""
     if [ ! -z "$G_OS1_INIT_CMDLINE_APPENDS" ]; then 
       logger "Appending options to CMDLINE: $G_OS1_INIT_CMDLINE_APPENDS"
@@ -223,7 +230,11 @@ load_OS2()
     F_COMMAND_LINE="\"$O_COMMAND_LINE_OVERRRIDE\""
   else
     TMP_COMMAND_LINE1=$(echo "$O_COMMAND_LINE" | sed -e "s/root\=\/dev\/mmcblk0p2/root\=\/dev\/mmcblk0p$G_OS2_PARTITION/")
-    TMP_COMMAND_LINE2=$(echo "$TMP_COMMAND_LINE1" | sed -e "s/ init\=\/sbin\/preinit/init\=$(echo $G_OS2_INITSCRIPT)/")
+    if [ ! -z "$G_OS2_INITSCRIPT" ]; then
+		TMP_COMMAND_LINE2=$(echo "$TMP_COMMAND_LINE1" | sed -e "s/ init\=\/sbin\/preinit/init\=$(echo $G_OS2_INITSCRIPT)/")
+	else
+		TMP_COMMAND_LINE2=$TMP_COMMAND_LINE1
+    fi
     F_COMMAND_LINE="\"$TMP_COMMAND_LINE2\""
     if [ ! -z "$G_OS2_INIT_CMDLINE_APPENDS" ]; then 
       logger "Appending options to CMDLINE: $G_OS2_INIT_CMDLINE_APPENDS"
@@ -265,7 +276,11 @@ load_OS3()
     F_COMMAND_LINE="\"$O_COMMAND_LINE_OVERRRIDE\""
   else
     TMP_COMMAND_LINE1=$(echo "$O_COMMAND_LINE" | sed -e "s/root\=\/dev\/mmcblk0p2/root\=\/dev\/mmcblk0p$G_OS3_PARTITION/")
-    TMP_COMMAND_LINE2=$(echo "$TMP_COMMAND_LINE1" | sed -e "s/ init\=\/sbin\/preinit/init\=$(echo $G_OS3_INITSCRIPT)/")
+    if [ ! -z "$G_OS3_INITSCRIPT" ]; then
+		TMP_COMMAND_LINE2=$(echo "$TMP_COMMAND_LINE1" | sed -e "s/ init\=\/sbin\/preinit/init\=$(echo $G_OS3_INITSCRIPT)/")
+	else
+		TMP_COMMAND_LINE2=$TMP_COMMAND_LINE1
+    fi
     F_COMMAND_LINE="\"$TMP_COMMAND_LINE2\""
     if [ ! -z "$G_OS3_INIT_CMDLINE_APPENDS" ]; then 
       logger "Appending options to CMDLINE: $G_OS3_INIT_CMDLINE_APPENDS"
@@ -307,7 +322,11 @@ load_OS4()
     F_COMMAND_LINE="\"$O_COMMAND_LINE_OVERRRIDE\""
   else
     TMP_COMMAND_LINE1=$(echo "$O_COMMAND_LINE" | sed -e "s/root\=\/dev\/mmcblk0p2/root\=\/dev\/mmcblk0p$G_OS4_PARTITION/")
-    TMP_COMMAND_LINE2=$(echo "$TMP_COMMAND_LINE1" | sed -e "s/ init\=\/sbin\/preinit/init\=$(echo $G_OS4_INITSCRIPT)/")
+    if [ ! -z "$G_OS4_INITSCRIPT" ]; then
+		TMP_COMMAND_LINE2=$(echo "$TMP_COMMAND_LINE1" | sed -e "s/ init\=\/sbin\/preinit/init\=$(echo $G_OS4_INITSCRIPT)/")
+	else
+		TMP_COMMAND_LINE2=$TMP_COMMAND_LINE1
+    fi
     F_COMMAND_LINE="\"$TMP_COMMAND_LINE2\""
     if [ ! -z "$G_OS4_INIT_CMDLINE_APPENDS" ]; then 
       logger "Appending options to CMDLINE: $G_OS4_INIT_CMDLINE_APPENDS"
@@ -349,7 +368,11 @@ load_OS5()
     F_COMMAND_LINE="\"$O_COMMAND_LINE_OVERRRIDE\""
   else
     TMP_COMMAND_LINE1=$(echo "$O_COMMAND_LINE" | sed -e "s/root\=\/dev\/mmcblk0p2/root\=\/dev\/mmcblk0p$G_OS5_PARTITION/")
-    TMP_COMMAND_LINE2=$(echo "$TMP_COMMAND_LINE1" | sed -e "s/ init\=\/sbin\/preinit/init\=$(echo $G_OS5_INITSCRIPT)/")
+    if [ ! -z "$G_OS5_INITSCRIPT" ]; then
+		TMP_COMMAND_LINE2=$(echo "$TMP_COMMAND_LINE1" | sed -e "s/ init\=\/sbin\/preinit/init\=$(echo $G_OS5_INITSCRIPT)/")
+	else
+		TMP_COMMAND_LINE2=$TMP_COMMAND_LINE1
+    fi
     F_COMMAND_LINE="\"$TMP_COMMAND_LINE2\""
     if [ ! -z "$G_OS5_INIT_CMDLINE_APPENDS" ]; then 
       logger "Appending options to CMDLINE: $G_OS5_INIT_CMDLINE_APPENDS"
@@ -391,7 +414,11 @@ load_OS6()
     F_COMMAND_LINE="\"$O_COMMAND_LINE_OVERRRIDE\""
   else
     TMP_COMMAND_LINE1=$(echo "$O_COMMAND_LINE" | sed -e "s/root\=\/dev\/mmcblk0p2/root\=\/dev\/mmcblk0p$G_OS6_PARTITION/")
-    TMP_COMMAND_LINE2=$(echo "$TMP_COMMAND_LINE1" | sed -e "s/ init\=\/sbin\/preinit/init\=$(echo $G_OS6_INITSCRIPT)/")
+    if [ ! -z "$G_OS6_INITSCRIPT" ]; then
+		TMP_COMMAND_LINE2=$(echo "$TMP_COMMAND_LINE1" | sed -e "s/ init\=\/sbin\/preinit/init\=$(echo $G_OS6_INITSCRIPT)/")
+	else
+		TMP_COMMAND_LINE2=$TMP_COMMAND_LINE1
+    fi
     F_COMMAND_LINE="\"$TMP_COMMAND_LINE2\""
     if [ ! -z "$G_OS6_INIT_CMDLINE_APPENDS" ]; then 
       logger "Appending options to CMDLINE: $G_OS6_INIT_CMDLINE_APPENDS"


### PR DESCRIPTION
This makes postamrketOS bootable by specifying initramfs via
G_OSX_KEXEC_OPTS parameter and leaving G_OSX_INITSCRIPT empty